### PR TITLE
Remove factor of 10 by default.  

### DIFF
--- a/cmake_modules/standard_flags.cmake
+++ b/cmake_modules/standard_flags.cmake
@@ -111,8 +111,8 @@ elseif(HAVE_UNDEFINED_BEHAVIOR_SANITIZER AND HAVE_FLAG_SANITIZE_BLACKLIST)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_UBSAN}")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${CMAKE_SHARED_LINKER_FLAGS_UBSAN}")
   message(STATUS "Undefined behaviour sanitiser is enabled. Use -DNO_UBSAN=TRUE to prevent.")
-  # Multiply all test timeouts by a factor of 1.
-  # ms_set_global_test_timeout_factor(1)
+  # Multiply all test timeouts by a factor of 1.5.
+  ms_set_global_test_timeout_factor(1.5)
 else()
   message(STATUS "Undefined behaviour sanitiser not available in this compiler.")
 endif()

--- a/cmake_modules/standard_flags.cmake
+++ b/cmake_modules/standard_flags.cmake
@@ -111,8 +111,8 @@ elseif(HAVE_UNDEFINED_BEHAVIOR_SANITIZER AND HAVE_FLAG_SANITIZE_BLACKLIST)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_UBSAN}")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${CMAKE_SHARED_LINKER_FLAGS_UBSAN}")
   message(STATUS "Undefined behaviour sanitiser is enabled. Use -DNO_UBSAN=TRUE to prevent.")
-  # Multiply all test timeouts by a factor of 10.
-  ms_set_global_test_timeout_factor(10)
+  # Multiply all test timeouts by a factor of 1.
+  ms_set_global_test_timeout_factor(1)
 else()
   message(STATUS "Undefined behaviour sanitiser not available in this compiler.")
 endif()

--- a/cmake_modules/standard_flags.cmake
+++ b/cmake_modules/standard_flags.cmake
@@ -111,8 +111,8 @@ elseif(HAVE_UNDEFINED_BEHAVIOR_SANITIZER AND HAVE_FLAG_SANITIZE_BLACKLIST)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_UBSAN}")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${CMAKE_SHARED_LINKER_FLAGS_UBSAN}")
   message(STATUS "Undefined behaviour sanitiser is enabled. Use -DNO_UBSAN=TRUE to prevent.")
-  # Multiply all test timeouts by a factor of 1.5.
-  ms_set_global_test_timeout_factor(1.5)
+  # Multiply all test timeouts by a factor of 2.
+  ms_set_global_test_timeout_factor(2)
 else()
   message(STATUS "Undefined behaviour sanitiser not available in this compiler.")
 endif()

--- a/cmake_modules/standard_flags.cmake
+++ b/cmake_modules/standard_flags.cmake
@@ -112,7 +112,7 @@ elseif(HAVE_UNDEFINED_BEHAVIOR_SANITIZER AND HAVE_FLAG_SANITIZE_BLACKLIST)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${CMAKE_SHARED_LINKER_FLAGS_UBSAN}")
   message(STATUS "Undefined behaviour sanitiser is enabled. Use -DNO_UBSAN=TRUE to prevent.")
   # Multiply all test timeouts by a factor of 1.
-  ms_set_global_test_timeout_factor(1)
+  # ms_set_global_test_timeout_factor(1)
 else()
   message(STATUS "Undefined behaviour sanitiser not available in this compiler.")
 endif()

--- a/cmake_modules/standard_setup.cmake
+++ b/cmake_modules/standard_setup.cmake
@@ -102,7 +102,7 @@ if(NOT DEFINED MEMORY_CHECK)
   endif()
 endif()
 if(MEMORY_CHECK)
-  ms_set_global_test_timeout_factor(20)
+  ms_set_global_test_timeout_factor(3)
 endif()
 
 if(UNIX)


### PR DESCRIPTION
Puts behavioural tests time-out at 60 seconds, and functional tests at 600 seconds.