### PR TITLE
Maid 714: Stop Protobuf generating illegal C++

### DIFF
--- a/src/third_party_libs/protobuf/src/google/protobuf/compiler/cpp/cpp_service.cc
+++ b/src/third_party_libs/protobuf/src/google/protobuf/compiler/cpp/cpp_service.cc
@@ -301,7 +301,7 @@ void ServiceGenerator::GenerateGetPrototype(RequestOrResponse which,
   printer->Print(vars_,
     "    default:\n"
     "      GOOGLE_LOG(FATAL) << \"Bad method index; this should never happen.\";\n"
-    "      return *reinterpret_cast< ::google::protobuf::Message*>(NULL);\n"
+    "      return *static_cast< ::google::protobuf::Message*>(NULL);\n"
     "  }\n"
     "}\n"
     "\n");


### PR DESCRIPTION
Let me know if the SHA stamping of the submodules is a problem.